### PR TITLE
feat(frontend): 비밀번호 모달 & 수집 완료 팝업

### DIFF
--- a/frontend/components/ui/overlay-loading.tsx
+++ b/frontend/components/ui/overlay-loading.tsx
@@ -17,7 +17,11 @@ export function OverlayLoading({
   return (
     <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-neutral-900/80">
       <div className="w-[90%] max-w-sm rounded-2xl bg-white p-6 text-center shadow-2xl dark:bg-neutral-900">
-        <div className="mx-auto mb-4 h-10 w-10 animate-spin rounded-full border-4 border-primary/30 border-t-primary" />
+        {title === "수집 완료" ? (
+          <div className="mx-auto mb-4 h-10 w-10 rounded-full border-4 border-green-500/30 bg-green-500/10" />
+        ) : (
+          <div className="mx-auto mb-4 h-10 w-10 animate-spin rounded-full border-4 border-primary/30 border-t-primary" />
+        )}
         <div className="text-lg font-semibold text-foreground">{title}</div>
         <div className="mt-1 text-sm text-muted-foreground">{description}</div>
       </div>

--- a/frontend/components/ui/password-modal.tsx
+++ b/frontend/components/ui/password-modal.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+type PasswordModalProps = {
+  visible: boolean;
+  examId: string;
+  format: string;
+  onConfirm: (password: string) => void;
+  onCancel: () => void;
+  errorMessage?: string;
+};
+
+export function PasswordModal({ visible, examId, format, onConfirm, onCancel, errorMessage }: PasswordModalProps) {
+  const [password, setPassword] = useState("");
+
+  useEffect(() => {
+    if (visible) setPassword("");
+  }, [visible]);
+
+  if (!visible) return null;
+  return (
+    <div className="fixed inset-0 z-[1050] flex items-center justify-center bg-neutral-900/80">
+      <div className="w-[92%] max-w-md rounded-2xl bg-white p-6 text-foreground shadow-2xl dark:bg-neutral-900">
+        <div className="text-lg font-semibold">보안 확인</div>
+        <div className="mt-1 text-sm text-muted-foreground">수집을 시작하려면 비밀번호를 입력해주세요.</div>
+
+        <div className="mt-4 rounded-xl border bg-muted/20 p-4">
+          <div className="text-sm font-medium">미리보기</div>
+          <div className="mt-2 grid grid-cols-3 gap-2 text-sm">
+            <div className="text-muted-foreground">시험 ID</div>
+            <div className="col-span-2 break-all">{examId || "-"}</div>
+            <div className="text-muted-foreground">파일 형식</div>
+            <div className="col-span-2 uppercase">{format}</div>
+          </div>
+        </div>
+
+        <div className="mt-4">
+          <label className="mb-1 block text-sm font-medium">비밀번호</label>
+          <Input
+            type="password"
+            placeholder="비밀번호를 입력하세요"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onConfirm(password);
+            }}
+          />
+          {errorMessage ? <div className="mt-2 text-sm text-red-600">{errorMessage}</div> : null}
+        </div>
+
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <Button variant="outline" onClick={onCancel}>취소</Button>
+          <Button className="bg-primary hover:bg-primary/90" onClick={() => onConfirm(password)}>확인</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+


### PR DESCRIPTION
- 수집 전 공통 비밀번호 입력 모달 추가 (미리보기 포함)\n- Vercel 환경변수 NEXT_PUBLIC_COLLECT_PASSWORD 사용\n- 수집 완료 시 오버레이 팝업 표시\n- 기존 '연결중' 오버레이 재사용\n\n검토 항목\n- 프론트 전용 변경이며 백엔드 연동/API 스펙 변경 없음\n- env: NEXT_PUBLIC_COLLECT_PASSWORD 설정 필요 (Vercel)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 수집 시작 전 비밀번호 확인 모달 추가; 올바른 비밀번호 입력 시에만 진행.
  - 비밀번호 검증 오류 메시지 표시 및 재시도 지원.
  - 수집 완료 시 1.8초간 완료 오버레이 표시로 피드백 강화.
  - 완료 상태에서 애니메이션 대신 정적 성공 인디케이터 표시.

- 작업
  - 백엔드 기본 URL을 프로덕션 호스트로 변경.
  - 외부 링크에 rel="noreferrer noopener" 적용으로 보안 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->